### PR TITLE
revert python aliases

### DIFF
--- a/badger.yaml
+++ b/badger.yaml
@@ -9,14 +9,3 @@ python-numpy:
   ubuntu:
     focal: [python3-numpy]
     '*': [python-numpy]
-python-pydbus:
-  ubuntu:
-    focal: [python3-pydbus]
-    xenial:
-      pip:
-        depends: [python-gi]
-        packages: [pydbus]
-python-gi:
-  ubuntu:
-    focal: [python3-gi]
-    '*': [python-gi]

--- a/badger.yaml
+++ b/badger.yaml
@@ -5,7 +5,3 @@ salt-minion:
   ubuntu: [salt-minion]
 salt-master:
   ubuntu: [salt-master]
-python-numpy:
-  ubuntu:
-    focal: [python3-numpy]
-    '*': [python-numpy]


### PR DESCRIPTION
I discovered that kinetic does support package.xml format=3 so we can solve
this the right way without hacking the rosdep data.
- Revert "Alias python-gi and python-pydbus for focal"
- Revert "Alias python-numpy to python3-numpy for focal"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/badgertechnologies/badger-rosdep/1)
<!-- Reviewable:end -->
